### PR TITLE
Ajustando problemas em cenários de CalcularTotalDePedidosNoMes.feature

### DIFF
--- a/features/CalcularTotalDePedidosNoMes.feature
+++ b/features/CalcularTotalDePedidosNoMes.feature
@@ -12,7 +12,7 @@ Feature: Calcular o valor total de pedidos no mês por restaurante
 		
 	Scenario: Visualizar o item mais pedido no mês de um restaurante
 		Given estou logado como usuário "cliente"
-		And minha conta pediu no restaurante "Tonho" durante esse mês os itens "5 pastel, 2 guaraná, 1 X-burger"
+		And minha conta pediu no restaurante "Tonho" neste mês os itens "5 pastel, 2 guaraná, 1 X-burger"
 		When eu abro a página "total de pedidos do mês"
 		And clico no restaurante "Tonho"
 		Then eu devo ver o valor total de pedidos nos restaurantes "Tonho"
@@ -26,18 +26,12 @@ Feature: Calcular o valor total de pedidos no mês por restaurante
 		Then eu devo ver o valor total de pedidos nos restaurantes "Almir"
 		And eu devo ver como itens mais pedidos "parmegiana" e "cajuína"
 
-	Scenario: Usuário quer ver o valor total de pedidos do mês mas não fez nenhuma compra
-		Given estou logado como usuário "cliente"
-		And minha conta não fez nenhum pedido ainda
-		When eu abro a página "total de pedidos do mês"
-		Then eu devo ver uma mensagem indicando que nada foi comprado ainda
-
 	Scenario: Usuário quer ver o valor total de pedidos do mês mas não fez nenhuma compra neste mês
 		Given estou logado como usuário "cliente"
 		And minha conta não fez nenhum pedido nesse mês
 		And minha conta fez pedidos em meses anteriores
 		When eu abro a página "total de pedidos do mês"
-		Then eu devo ver uma mensagem indicando que nada foi comprado ainda nesse mês
+		Then eu devo ver uma mensagem indicando "nada foi comprado nesse mês"
 		
 	# Cénarios de falha
 	Scenario: Usuário quer ver o valor total de pedidos do mês mas não foi possível carregar histórico de pedidos


### PR DESCRIPTION
- Cenário de nenhum pedido é redundante, será trabalhado na feature histórico de pedidos e aqui só se visualiza por mês
- Avaliando necessidade de parametrizar de forma extensa o cenário "Visualizar o valor total de compras desse mês para cada restaurante", se é necessário colocar por extenso os pedidos
- Avaliando se no cenário "Usuário quer ver o valor total de pedidos do mês mas não fez nenhuma compra neste mês" o "não fez nenhum pedido nesse mês" é válido pois tecnicamente é uma não-ação